### PR TITLE
missing typescript types when import subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "typesVersions": {
-    "*": {
+    "<=4.9": {
       "*": [
-        "./dist/*"
+        "./dist/*",
+        "./*"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,13 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*"
+      ]
+    }
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
```typescript
// now UnpluginStarter no typescript types intellisence
import UnpluginStarter from 'unplugin-starter/vite'

export default defineConfig({
  plugins: [UnpluginStarter()],
})
```